### PR TITLE
refactor: Rename plugin from dev-agents to ahngbeom-dev-agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "dev-agents",
+      "name": "ahngbeom-dev-agents",
       "description": "Development agents for API design, Node.js, Spring Boot, database, frontend, and testing",
       "source": "./",
       "strict": false,


### PR DESCRIPTION
## Summary
- Rename plugin name from `dev-agents` to `ahngbeom-dev-agents` for better marketplace distinction

## Test plan
- [ ] Verify plugin loads correctly with new name
- [ ] Check agent references still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)