### PR TITLE
feat: Improve agent auto-invocation with example-based descriptions

### DIFF
--- a/plugins/backend-agents/agents/backend-api-architect.md
+++ b/plugins/backend-agents/agents/backend-api-architect.md
@@ -1,6 +1,6 @@
 ---
 name: backend-api-architect
-description: API design principles, RESTful/GraphQL patterns, authentication concepts, and microservices architecture. Use for API design decisions and architectural guidance.
+description: Use this agent when the user needs to design APIs, implement REST/GraphQL endpoints, or make architectural decisions about backend services. This includes scenarios like:\n\n<example>\nContext: User wants to design a new API endpoint\nuser: "I need to design a REST API for user authentication with JWT tokens"\nassistant: "I'll use the backend-api-architect agent to design your authentication API."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about API patterns in Korean\nuser: "로그인 API 설계해줘"\nassistant: "I'll use the backend-api-architect agent to design your login API."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs GraphQL schema design\nuser: "Help me design a GraphQL schema for my e-commerce product catalog"\nassistant: "I'll use the backend-api-architect agent to design your GraphQL schema."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "API", "엔드포인트", "REST", "GraphQL", "OAuth", "JWT", "마이크로서비스", "API 설계", "endpoint"
 model: sonnet
 color: purple
 ---

--- a/plugins/backend-agents/agents/database-expert.md
+++ b/plugins/backend-agents/agents/database-expert.md
@@ -1,6 +1,6 @@
 ---
 name: database-expert
-description: Senior database architect specializing in PostgreSQL/MySQL schema design, query optimization, indexing strategies, and migration management. Use when designing schemas, optimizing queries, or managing database migrations.
+description: Use this agent when the user needs database schema design, query optimization, migration management, or indexing strategies. This includes scenarios like:\n\n<example>\nContext: User wants to add a new field\nuser: "유저 테이블에 프로필 이미지 필드 추가해줘"\nassistant: "I'll use the database-expert agent to create a migration."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User has slow queries\nuser: "This query is taking 5 seconds, can you optimize it?"\nassistant: "I'll use the database-expert agent to optimize your slow query."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs schema design\nuser: "스키마 설계 도와줘 - 주문과 결제 테이블 관계"\nassistant: "I'll use the database-expert agent to design the relationships."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "스키마", "쿼리", "migration", "인덱스", "DB", "PostgreSQL", "MySQL", "테이블", "데이터베이스", "query optimization"
 model: sonnet
 color: orange
 ---

--- a/plugins/backend-agents/agents/nodejs-backend.md
+++ b/plugins/backend-agents/agents/nodejs-backend.md
@@ -1,6 +1,6 @@
 ---
 name: nodejs-backend
-description: Senior Node.js/Express backend engineer specializing in TypeScript, middleware patterns, and async processing. Use when implementing Node.js APIs or backend services.
+description: Use this agent when the user needs to build Node.js/Express backend services, implement middleware, or work with TypeScript backend code. This includes scenarios like:\n\n<example>\nContext: User wants to create Express middleware\nuser: "Express 인증 미들웨어 만들어줘"\nassistant: "I'll use the nodejs-backend agent to create the authentication middleware."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Node.js API implementation\nuser: "Build a REST API with Express and TypeScript"\nassistant: "I'll use the nodejs-backend agent to implement your Express API."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about async patterns\nuser: "How should I handle async errors in Express?"\nassistant: "I'll use the nodejs-backend agent to help with async error handling."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "Express", "Node.js", "미들웨어", "middleware", "NestJS", "TypeScript backend", "async", "npm"
 model: sonnet
 color: green
 ---

--- a/plugins/backend-agents/agents/python-fastapi-backend.md
+++ b/plugins/backend-agents/agents/python-fastapi-backend.md
@@ -1,6 +1,6 @@
 ---
 name: python-fastapi-backend
-description: Senior Python backend developer specializing in FastAPI, Pydantic, async programming, and ML integration. Use for Python API development with FastAPI.
+description: Use this agent when the user needs to build Python APIs with FastAPI, implement Pydantic schemas, or integrate ML services. This includes scenarios like:\n\n<example>\nContext: User wants to create a FastAPI endpoint\nuser: "FastAPI로 이미지 업로드 API 만들어줘"\nassistant: "I'll use the python-fastapi-backend agent to create your image upload API."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Pydantic validation\nuser: "How do I validate request body with Pydantic?"\nassistant: "I'll use the python-fastapi-backend agent to help with Pydantic validation."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about async Python\nuser: "async 데이터베이스 연결 구현해줘"\nassistant: "I'll use the python-fastapi-backend agent to implement async database connection."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "FastAPI", "Pydantic", "uvicorn", "Python API", "async Python", "SQLAlchemy", "alembic", "Python 백엔드"
 model: sonnet
 color: green
 ---

--- a/plugins/backend-agents/agents/spring-boot-backend.md
+++ b/plugins/backend-agents/agents/spring-boot-backend.md
@@ -1,6 +1,6 @@
 ---
 name: spring-boot-backend
-description: Senior Spring Boot architect specializing in Java, layered architecture, and Spring Security. Use when implementing Java APIs or Spring-based backend services.
+description: Use this agent when the user needs to build Spring Boot applications, implement Java APIs, or work with Spring Security. This includes scenarios like:\n\n<example>\nContext: User wants to create a Spring Boot service\nuser: "Spring Boot로 회원 관리 API 만들어줘"\nassistant: "I'll use the spring-boot-backend agent to create your user management API."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Spring Security setup\nuser: "How do I configure JWT authentication in Spring Boot?"\nassistant: "I'll use the spring-boot-backend agent to configure JWT authentication."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about JPA\nuser: "JPA Entity 관계 설정 도와줘"\nassistant: "I'll use the spring-boot-backend agent to help with JPA entity relationships."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "Spring", "Java", "JPA", "Spring Boot", "Hibernate", "Spring Security", "Gradle", "Maven", "@Controller", "@Service"
 model: sonnet
 color: orange
 ---

--- a/plugins/data-agents/agents/computer-vision-engineer.md
+++ b/plugins/data-agents/agents/computer-vision-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: computer-vision-engineer
-description: Senior computer vision engineer specializing in face detection, landmark analysis, MediaPipe, OpenCV, and real-time video processing. Use for face recognition, image analysis, and AR applications.
+description: Use this agent when the user needs face detection, landmark analysis, image processing, or AR applications. This includes scenarios like:\n\n<example>\nContext: User wants face detection\nuser: "얼굴 인식 기능 구현해줘"\nassistant: "I'll use the computer-vision-engineer agent for face detection."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs landmark analysis\nuser: "Implement facial landmark detection with MediaPipe"\nassistant: "I'll use the computer-vision-engineer agent for landmark detection."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about AR filters\nuser: "AR 필터 개발해줘"\nassistant: "I'll use the computer-vision-engineer agent for AR filter development."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "얼굴 인식", "MediaPipe", "OpenCV", "face_recognition", "랜드마크", "AR 필터", "이미지 처리", "computer vision"
 model: sonnet
 color: magenta
 ---

--- a/plugins/data-agents/agents/data-analyst.md
+++ b/plugins/data-agents/agents/data-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: data-analyst
-description: Senior data analyst specializing in Python, Pandas, SQL, visualization, and statistical analysis. Use for data analysis, EDA, and insights.
+description: Use this agent when the user needs data analysis, statistical insights, or visualization. This includes scenarios like:\n\n<example>\nContext: User wants to analyze data\nuser: "데이터 분석해줘"\nassistant: "I'll use the data-analyst agent to analyze your data."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs visualization\nuser: "Create a visualization for sales trends"\nassistant: "I'll use the data-analyst agent to create your visualization."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about statistics\nuser: "이 데이터에 대한 통계 분석 진행해줘"\nassistant: "I'll use the data-analyst agent for statistical analysis."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "데이터 분석", "통계", "Pandas", "시각화", "EDA", "분석", "visualization", "Matplotlib", "SQL 분석"
 model: sonnet
 color: teal
 ---

--- a/plugins/data-agents/agents/data-engineer.md
+++ b/plugins/data-agents/agents/data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: data-engineer
-description: Senior data engineer specializing in data pipelines, ETL/ELT, Spark, Airflow, and data warehouse architecture. Use for data infrastructure and pipeline tasks.
+description: Use this agent when the user needs to build data pipelines, implement ETL/ELT processes, or design data warehouse architecture. This includes scenarios like:\n\n<example>\nContext: User wants to build a pipeline\nuser: "Airflow DAG 작성해줘"\nassistant: "I'll use the data-engineer agent to create your Airflow DAG."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Spark processing\nuser: "How do I process large CSV files with Spark?"\nassistant: "I'll use the data-engineer agent for Spark processing."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about data warehouse\nuser: "데이터 웨어하우스 스키마 설계해줘"\nassistant: "I'll use the data-engineer agent for warehouse schema design."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "ETL", "파이프라인", "Spark", "Airflow", "데이터 웨어하우스", "dbt", "Kafka", "data lake", "pipeline"
 model: sonnet
 color: indigo
 ---

--- a/plugins/data-agents/agents/ml-engineer.md
+++ b/plugins/data-agents/agents/ml-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: ml-engineer
-description: Senior ML engineer specializing in PyTorch, TensorFlow, model training, and MLOps. Use for machine learning model development and deployment.
+description: Use this agent when the user needs to develop ML models, implement training pipelines, or deploy AI services. This includes scenarios like:\n\n<example>\nContext: User wants to train a model\nuser: "모델 학습 코드 작성해줘"\nassistant: "I'll use the ml-engineer agent for model training."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs fine-tuning help\nuser: "How do I fine-tune LLaMA with LoRA?"\nassistant: "I'll use the ml-engineer agent for LoRA fine-tuning."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about MLOps\nuser: "MLflow로 실험 관리 어떻게 해?"\nassistant: "I'll use the ml-engineer agent for MLflow setup."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "모델 학습", "PyTorch", "TensorFlow", "MLOps", "LLM", "fine-tuning", "RAG", "training", "inference", "딥러닝"
 model: sonnet
 color: pink
 ---

--- a/plugins/devops-agents/agents/devops-engineer.md
+++ b/plugins/devops-agents/agents/devops-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: devops-engineer
-description: Senior DevOps/SRE engineer specializing in ELK Stack, Kubernetes, CI/CD pipelines, and cloud infrastructure. Use for monitoring, deployment, and infrastructure tasks.
+description: Use this agent when the user needs CI/CD pipelines, Docker configuration, Kubernetes deployments, or infrastructure automation. This includes scenarios like:\n\n<example>\nContext: User needs deployment setup\nuser: "배포 파이프라인 설정해줘"\nassistant: "I'll use the devops-engineer agent for pipeline setup."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Docker help\nuser: "Create a Dockerfile for my Node.js application"\nassistant: "I'll use the devops-engineer agent to create your Dockerfile."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about Kubernetes\nuser: "How do I configure HPA for my deployment?"\nassistant: "I'll use the devops-engineer agent for HPA configuration."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "배포", "CI/CD", "Docker", "Kubernetes", "Terraform", "EKS", "Prometheus", "Grafana", "인프라", "deployment"
 model: sonnet
 color: red
 ---

--- a/plugins/devops-agents/agents/github-expert.md
+++ b/plugins/devops-agents/agents/github-expert.md
@@ -1,6 +1,6 @@
 ---
 name: github-expert
-description: Senior GitHub specialist focusing on GitHub Actions workflows, CI/CD automation, GitHub CLI, and repository management. Use for workflow design, Actions optimization, and GitHub features configuration.
+description: Use this agent when the user needs GitHub Actions workflows, CI/CD automation, or GitHub CLI operations. This includes scenarios like:\n\n<example>\nContext: User wants a GitHub workflow\nuser: "GitHub Actions workflow 작성해줘"\nassistant: "I'll use the github-expert agent to create your workflow."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs CI/CD with GitHub\nuser: "Set up automated testing with GitHub Actions"\nassistant: "I'll use the github-expert agent for CI/CD setup."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about GitHub CLI\nuser: "gh CLI로 PR 생성하는 방법"\nassistant: "I'll use the github-expert agent to help with GitHub CLI."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "GitHub Actions", "workflow", "gh", "GitHub CLI", ".github/workflows", "GitHub", "Actions"
 model: sonnet
 color: gray
 ---

--- a/plugins/devops-agents/agents/gitlab-expert.md
+++ b/plugins/devops-agents/agents/gitlab-expert.md
@@ -1,6 +1,6 @@
 ---
 name: gitlab-expert
-description: Senior GitLab specialist focusing on CI/CD pipelines, .gitlab-ci.yml configuration, GitLab Runner setup, and DevSecOps workflows. Use for GitLab pipeline design, optimization, and troubleshooting.
+description: Use this agent when the user needs GitLab CI/CD pipelines, .gitlab-ci.yml configuration, or GitLab Runner setup. This includes scenarios like:\n\n<example>\nContext: User wants a GitLab pipeline\nuser: "GitLab CI 파이프라인 설정해줘"\nassistant: "I'll use the gitlab-expert agent for pipeline configuration."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs .gitlab-ci.yml help\nuser: "Write a .gitlab-ci.yml for my Node.js project"\nassistant: "I'll use the gitlab-expert agent to create your .gitlab-ci.yml."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about GitLab Runner\nuser: "GitLab Runner 설정 방법"\nassistant: "I'll use the gitlab-expert agent for Runner setup."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "GitLab CI", ".gitlab-ci.yml", "GitLab Runner", "GitLab", "GitLab pipeline"
 model: sonnet
 color: orange
 ---

--- a/plugins/frontend-agents/agents/frontend-engineer.md
+++ b/plugins/frontend-agents/agents/frontend-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-engineer
-description: Senior React/Next.js UI engineer specializing in component architecture, state management, and modern CSS-in-JS solutions. Use when building UI components, managing state, or optimizing frontend performance.
+description: Use this agent when the user needs to build React/Next.js components, implement state management, or optimize frontend performance. This includes scenarios like:\n\n<example>\nContext: User wants to create a component\nuser: "사용자 프로필 컴포넌트 만들어줘"\nassistant: "I'll use the frontend-engineer agent to create your profile component."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs state management help\nuser: "How should I manage global state in my Next.js app?"\nassistant: "I'll use the frontend-engineer agent to help with state management."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs UI implementation\nuser: "Build a responsive dashboard layout with Tailwind"\nassistant: "I'll use the frontend-engineer agent to build your dashboard."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "컴포넌트", "리액트", "React", "Vue", "Next.js", "UI", "Tailwind", "상태 관리", "useState", "CSS"
 model: sonnet
 color: blue
 ---

--- a/plugins/healthcare-agents/agents/healthcare-stats-forecaster.md
+++ b/plugins/healthcare-agents/agents/healthcare-stats-forecaster.md
@@ -1,6 +1,6 @@
 ---
 name: healthcare-stats-forecaster
-description: Senior healthcare data scientist specializing in medical time series forecasting, disease outbreak prediction, patient volume forecasting, and clinical outcome prediction. Use for healthcare prediction models and trend analysis.
+description: Use this agent when the user needs healthcare forecasting, disease prediction, or medical time series analysis. This includes scenarios like:\n\n<example>\nContext: User wants patient volume forecasting\nuser: "환자 수요 예측 모델 만들어줘"\nassistant: "I'll use the healthcare-stats-forecaster agent for demand forecasting."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs disease prediction\nuser: "Predict disease outbreak trends"\nassistant: "I'll use the healthcare-stats-forecaster agent for outbreak prediction."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about medical time series\nuser: "의료 시계열 예측해줘"\nassistant: "I'll use the healthcare-stats-forecaster agent for time series forecasting."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "의료 예측", "disease prediction", "환자 수요", "outbreak", "time series", "forecasting", "헬스케어 예측"
 model: sonnet
 color: purple
 ---

--- a/plugins/healthcare-agents/agents/healthcare-stats-normalizer.md
+++ b/plugins/healthcare-agents/agents/healthcare-stats-normalizer.md
@@ -1,6 +1,6 @@
 ---
 name: healthcare-stats-normalizer
-description: Senior healthcare data engineer specializing in medical data normalization, standardization, code mapping (ICD, SNOMED), and data quality. Use for cleaning, transforming, and standardizing healthcare statistics data.
+description: Use this agent when the user needs to normalize, standardize, or clean healthcare data. This includes scenarios like:\n\n<example>\nContext: User wants to map medical codes\nuser: "ICD-10 코드 매핑해줘"\nassistant: "I'll use the healthcare-stats-normalizer agent for code mapping."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs data standardization\nuser: "Normalize this patient data to FHIR format"\nassistant: "I'll use the healthcare-stats-normalizer agent for FHIR normalization."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about data quality\nuser: "의료 데이터 정규화해줘"\nassistant: "I'll use the healthcare-stats-normalizer agent for data normalization."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "의료 데이터", "ICD", "SNOMED", "FHIR", "데이터 정규화", "code mapping", "healthcare data"
 model: sonnet
 color: cyan
 ---

--- a/plugins/healthcare-agents/agents/healthcare-stats-tester.md
+++ b/plugins/healthcare-agents/agents/healthcare-stats-tester.md
@@ -1,6 +1,6 @@
 ---
 name: healthcare-stats-tester
-description: Senior biostatistician specializing in medical statistics, hypothesis testing, clinical trial analysis, and healthcare data validation. Use for statistical testing, significance analysis, and clinical research methodology.
+description: Use this agent when the user needs biostatistical analysis, hypothesis testing, or clinical trial analysis. This includes scenarios like:\n\n<example>\nContext: User wants statistical testing\nuser: "임상 데이터 통계 분석해줘"\nassistant: "I'll use the healthcare-stats-tester agent for statistical analysis."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs hypothesis testing\nuser: "Run a t-test on this patient outcome data"\nassistant: "I'll use the healthcare-stats-tester agent for hypothesis testing."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about clinical trials\nuser: "Sample size 계산해줘"\nassistant: "I'll use the healthcare-stats-tester agent for sample size calculation."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "임상 통계", "hypothesis testing", "t-test", "ANOVA", "survival analysis", "clinical trial", "생존분석"
 model: sonnet
 color: orange
 ---

--- a/plugins/mobile-agents/agents/ar-mobile-developer.md
+++ b/plugins/mobile-agents/agents/ar-mobile-developer.md
@@ -1,6 +1,6 @@
 ---
 name: ar-mobile-developer
-description: Senior AR mobile developer specializing in ARCore, ARKit, Flutter AR plugins, face filters, and real-time 3D overlay. Use for augmented reality features in mobile apps.
+description: Use this agent when the user needs AR features in mobile apps, face filters, or 3D overlay effects. This includes scenarios like:\n\n<example>\nContext: User wants AR features\nuser: "ARKit으로 얼굴 필터 만들어줘"\nassistant: "I'll use the ar-mobile-developer agent to create your face filter."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs AR overlay\nuser: "Implement AR object placement with ARCore"\nassistant: "I'll use the ar-mobile-developer agent for AR object placement."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about face mesh\nuser: "AR 메이크업 필터 개발해줘"\nassistant: "I'll use the ar-mobile-developer agent for AR makeup filter."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "ARCore", "ARKit", "AR 필터", "얼굴 필터", "증강현실", "Face Mesh", "3D overlay", "face tracking"
 model: sonnet
 color: teal
 ---

--- a/plugins/mobile-agents/agents/desktop-app-developer.md
+++ b/plugins/mobile-agents/agents/desktop-app-developer.md
@@ -1,6 +1,6 @@
 ---
 name: desktop-app-developer
-description: Senior desktop app developer specializing in Electron and Tauri. Use when building cross-platform desktop applications.
+description: Use this agent when the user needs to build cross-platform desktop applications with Electron or Tauri. This includes scenarios like:\n\n<example>\nContext: User wants an Electron app\nuser: "Electron으로 데스크톱 앱 만들어줘"\nassistant: "I'll use the desktop-app-developer agent to create your Electron app."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Tauri development\nuser: "Build a Tauri app with system tray"\nassistant: "I'll use the desktop-app-developer agent for Tauri development."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about IPC\nuser: "How do I communicate between main and renderer process?"\nassistant: "I'll use the desktop-app-developer agent for IPC implementation."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "Electron", "Tauri", "데스크톱 앱", "desktop app", "system tray", "IPC", "cross-platform desktop"
 model: sonnet
 color: yellow
 ---

--- a/plugins/mobile-agents/agents/mobile-app-developer.md
+++ b/plugins/mobile-agents/agents/mobile-app-developer.md
@@ -1,6 +1,6 @@
 ---
 name: mobile-app-developer
-description: Senior mobile app developer specializing in React Native, Flutter, Swift, and Kotlin. Use when building iOS/Android apps.
+description: Use this agent when the user needs to build iOS/Android mobile apps using React Native, Flutter, or native development. This includes scenarios like:\n\n<example>\nContext: User wants to create a mobile app\nuser: "React Native로 모바일 앱 만들어줘"\nassistant: "I'll use the mobile-app-developer agent to create your React Native app."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs Flutter development\nuser: "Build a Flutter app with navigation"\nassistant: "I'll use the mobile-app-developer agent to build your Flutter app."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User asks about native iOS\nuser: "SwiftUI 화면 구현해줘"\nassistant: "I'll use the mobile-app-developer agent for SwiftUI implementation."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: "React Native", "Flutter", "iOS", "Android", "모바일 앱", "Swift", "Kotlin", "Expo", "mobile app"
 model: sonnet
 color: cyan
 ---

--- a/plugins/productivity-agents/agents/test-automation-engineer.md
+++ b/plugins/productivity-agents/agents/test-automation-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: test-automation-engineer
-description: Senior test automation engineer focusing on Jest/Vitest unit tests, React Testing Library, Playwright E2E tests, and TDD workflows. Use when writing tests, improving coverage, or implementing TDD.
+description: Use this agent when the user needs to write tests, improve test coverage, or implement TDD workflows. This includes scenarios like:\n\n<example>\nContext: User wants to add tests\nuser: "테스트 코드 작성해줘"\nassistant: "I'll use the test-automation-engineer agent to write tests."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User needs E2E tests\nuser: "Write Playwright tests for the login flow"\nassistant: "I'll use the test-automation-engineer agent for E2E tests."\n<tool>Agent</tool>\n</example>\n\n<example>\nContext: User wants TDD\nuser: "Let's build this feature using TDD"\nassistant: "I'll use the test-automation-engineer agent for TDD guidance."\n<tool>Agent</tool>\n</example>\n\nNote: Use proactively after feature implementations. Keywords: "테스트", "test", "Jest", "Vitest", "Playwright", "pytest", "TDD", "unit test", "coverage"
 model: sonnet
 color: yellow
 ---


### PR DESCRIPTION
## Summary
- Update description fields in **20 agent files** to enable automatic agent invocation
- Each agent now includes `<example>` blocks with user/assistant dialog patterns
- Support both English and Korean prompts for auto-triggering

## Changes

### Description Template Pattern
Each agent description now follows this structure:
```yaml
description: Use this agent when [trigger conditions]...\n\n<example>\nContext: [situation]\nuser: "[prompt]"\nassistant: "I'll use the [agent-name] agent..."\n<tool>Agent</tool>\n</example>\n\nNote: Auto-trigger keywords: [keywords]
```

### Agents Updated (20 files)

| Plugin | Agents |
|--------|--------|
| backend-agents | backend-api-architect, database-expert, nodejs-backend, spring-boot-backend, python-fastapi-backend |
| frontend-agents | frontend-engineer |
| devops-agents | devops-engineer, github-expert, gitlab-expert |
| data-agents | ml-engineer, data-engineer, data-analyst, computer-vision-engineer |
| mobile-agents | mobile-app-developer, ar-mobile-developer, desktop-app-developer |
| healthcare-agents | healthcare-stats-normalizer, healthcare-stats-tester, healthcare-stats-forecaster |
| productivity-agents | test-automation-engineer |

## Test plan
- [ ] Restart Claude Code or run `/refresh`
- [ ] Test Korean prompts: "로그인 API 설계해줘" → should trigger backend-api-architect
- [ ] Test English prompts: "Write Playwright E2E tests" → should trigger test-automation-engineer
- [ ] Verify agents are invoked without explicitly mentioning agent names

🤖 Generated with [Claude Code](https://claude.com/claude-code)